### PR TITLE
Update jet_correction_analyzer_x.cc

### DIFF
--- a/JetAnalyzers/bin/jet_correction_analyzer_x.cc
+++ b/JetAnalyzers/bin/jet_correction_analyzer_x.cc
@@ -18,7 +18,8 @@
 #include "CondFormats/JetMETObjects/interface/FactorizedJetCorrector.h"
 #include "PhysicsTools/Utilities/interface/LumiReWeighting.h"
 #if __has_include("xrootd/XrdCl/XrdClFileSystem.hh")
-#include "xrootd/XrdCl/XrdClFileSystem.hh"
+//#include "xrootd/XrdCl/XrdClFileSystem.hh"
+#include "condor/XrdClFileSystem_v2.hh"
 #define has_xrdcl 1
 #else
 #define has_xrdcl 0
@@ -215,7 +216,7 @@ int main(int argc,char**argv)
 
    edm::LumiReWeighting LumiWeights_;
    if(!MCPUReWeighting.IsNull() && !DataPUReWeighting.IsNull()) {
-      LumiWeights_ = edm::LumiReWeighting(string(MCPUReWeighting),string(DataPUReWeighting),"pileup","pileup");
+      LumiWeights_ = edm::LumiReWeighting(string(MCPUReWeighting),string(DataPUReWeighting),"h_pileup","pileup");
    }
 
    if(!outputDir.IsNull() && !outputDir.EndsWith("/")) outputDir += "/";
@@ -603,6 +604,13 @@ int main(int argc,char**argv)
 
          if(nrefmax>0 && JRAEvt->nref>nrefmax) JRAEvt->nref = nrefmax;
          for (unsigned char iref=0;iref<JRAEvt->nref;iref++) {
+	    /*      
+         //=== veto region for UL2017 =======
+        //if((JRAEvt->jtphi->at(iref)<-0.5236 && JRAEvt->jtphi->at(iref)>-0.8727 && JRAEvt->jteta->at(iref) >1.31 && JRAEvt->jteta->at(iref)<2.96) || (JRAEvt->jtphi->at(iref)>2.705 && JRAEvt->jtphi->at(iref)<3.1416 && JRAEvt->jteta->at(iref) >0 && JRAEvt->jteta->at(iref)<1.4835) )continue;
+        //=== veto region for UL2018 =======
+       //if((JRAEvt->jtphi->at(iref)<-0.8727 && JRAEvt->jtphi->at(iref)>-1.5708 && JRAEvt->jteta->at(iref) < -1.31 && JRAEvt->jteta->at(iref)> -2.96) || (JRAEvt->jtphi->at(iref)>0.4363 && JRAEvt->jtphi->at(iref)<0.7854 && JRAEvt->jteta->at(iref) >0 && JRAEvt->jteta->at(iref)<1.31) )continue;
+*/
+//	    if(JRAEvt->npv>0 && JRAEvt->npv<10){  //nVtx cut starts here
             float rho = JRAEvt->rho;
             float rho_hlt = (0!=chain->GetBranch("rho_hlt")) ? JRAEvt->rho_hlt : 0;
             float ptgen  = JRAEvt->refpt->at(iref);
@@ -858,6 +866,7 @@ int main(int argc,char**argv)
                ThetaDistribution ->Fill(theta);
                SolidAngleDist ->Fill(2*TMath::Pi()*cos(theta));
             }
+//	    }//nVtx ends here
          }//for (unsigned char iref=0;iref<nrefmax;iref++) 
       }//for (unsigned int ievt=0;ievt<nevt;ievt++)
 


### PR DESCRIPTION
Veto regions for UL2017 and UL2018 are added and commented out.